### PR TITLE
Update _transport.asciidoc

### DIFF
--- a/v1/_transport.asciidoc
+++ b/v1/_transport.asciidoc
@@ -34,7 +34,7 @@ IMPORTANT: If TLS is enabled, and no certificate has been specified, the server 
 After connecting, a handshake takes place to establish which Bolt protocol version should be used for that connection.
 This handshake is a _version-independent_ mini-protocol which is guaranteed to remain the same, regardless of preferred or available protocol versions.
 
-In the handshake, the client fist sends a magic four byte preamble (6060 B017) followed by four protocol versions it supports, in order of preference.
+In the handshake, the client first sends a magic four byte preamble (6060 B017) followed by four protocol versions it supports, in order of preference.
 The proposal is always represented as four 32-bit unsigned integers.
 Each integer represents a proposed protocol version to use, or zero (`00 00 00 00`) for "none".
 


### PR DESCRIPTION
Fixed a typo in the documentation.